### PR TITLE
Kav/fix edit link crash - Fixes #28

### DIFF
--- a/nerdlets/observability-maps-nerdlet/components/link/edit/hover-metrics.js
+++ b/nerdlets/observability-maps-nerdlet/components/link/edit/hover-metrics.js
@@ -25,15 +25,16 @@ export default class HoverMetrics extends React.PureComponent {
       hm_1_ACC: null,
       hm_2_ACC: null,
       hm_3_ACC: null,
-      selectedHoverOption: null
+      selectedHoverOption: null,
+      editorsSet: false
     };
   }
 
   componentDidMount() {
     const customMode = new CustomNrqlMode();
-    const editor0 = this.aceEditor0.editor.getSession().setMode(customMode);
-    const editor1 = this.aceEditor1.editor.getSession().setMode(customMode);
-    const editor2 = this.aceEditor2.editor.getSession().setMode(customMode);
+    this.aceEditor0.editor.getSession().setMode(customMode);
+    this.aceEditor1.editor.getSession().setMode(customMode);
+    this.aceEditor2.editor.getSession().setMode(customMode);
   }
 
   saveNrqlMulti = async (
@@ -169,100 +170,102 @@ export default class HoverMetrics extends React.PureComponent {
                   onChange={(e, d) => updateHoverType(d.value)}
                 />
               </Form.Group>
+              <div
+                style={{
+                  display: selectedHoverOption === 'customNrql' ? '' : 'none'
+                }}
+              >
+                <Header as="h4">Set up to 3 NRQL custom queries</Header>
+                <Header as="h5">
+                  Tip: Validate your queries in the chart builder.
+                </Header>
 
-              {selectedHoverOption === 'customNrql' ? (
-                <>
-                  <Header as="h4">Set up to 3 NRQL custom queries</Header>
-                  <Header as="h5">
-                    Tip: Validate your queries in the chart builder.
-                  </Header>
-
-                  {[1, 2, 3].map((metric, i) => {
-                    return (
-                      <React.Fragment key={i}>
-                        <Form.Group widths={16}>
-                          <Form.Field width={11}>
-                            <label>Query {i + 1}</label>
-                            <div
-                              className="App"
-                              style={{
-                                backgroundColor: '#202020',
-                                paddingTop: '10px'
+                {[1, 2, 3].map((metric, i) => {
+                  return (
+                    <React.Fragment key={i}>
+                      <Form.Group widths={16}>
+                        <Form.Field width={11}>
+                          <label>Query {i + 1}</label>
+                          <div
+                            className="App"
+                            style={{
+                              backgroundColor: '#202020',
+                              paddingTop: '10px'
+                            }}
+                          >
+                            <AceEditor
+                              ref={c => {
+                                this[`aceEditor${i}`] = c;
                               }}
-                            >
-                              <AceEditor
-                                ref={c => {
-                                  this[`aceEditor${i}`] = c;
-                                }}
-                                height="27px"
-                                width="100%"
-                                mode="text"
-                                theme="monokai"
-                                name={`hm_${i + 1}_NRQL`}
-                                editorProps={{ $blockScrolling: false }}
-                                // maxLines={1}
-                                fontFamily="monospace"
-                                fontSize={14}
-                                showGutter={false}
-                                value={value(`hm_${i + 1}_NRQL`)}
-                                onChange={str =>
-                                  this.setState({
-                                    [`hm_${i + 1}_NRQL`]: str
-                                  })
-                                }
-                              />
-                            </div>
-                          </Form.Field>
+                              height="27px"
+                              width="100%"
+                              mode="text"
+                              theme="monokai"
+                              name={`hm_${i + 1}_NRQL`}
+                              editorProps={{ $blockScrolling: false }}
+                              // maxLines={1}
+                              fontFamily="monospace"
+                              fontSize={14}
+                              showGutter={false}
+                              value={value(`hm_${i + 1}_NRQL`)}
+                              onChange={str =>
+                                this.setState({
+                                  [`hm_${i + 1}_NRQL`]: str
+                                })
+                              }
+                            />
+                          </div>
+                        </Form.Field>
 
-                          <Form.Select
-                            search
-                            width={3}
-                            label="Account"
-                            value={value(`hm_${i + 1}_ACC`)}
-                            options={accountOptions}
-                            onChange={(e, d) =>
-                              this.setState({ [`hm_${i + 1}_ACC`]: d.value })
-                            }
-                          />
+                        <Form.Select
+                          search
+                          width={3}
+                          label="Account"
+                          value={value(`hm_${i + 1}_ACC`)}
+                          options={accountOptions}
+                          onChange={(e, d) =>
+                            this.setState({ [`hm_${i + 1}_ACC`]: d.value })
+                          }
+                        />
 
-                          <Form.Field width={2}>
-                            <label>&nbsp;</label>
-                            <div style={{ textAlign: 'right' }}>
-                              <Button
-                                style={{ maxWidth: '52px' }}
-                                icon="check"
-                                positive
-                                onClick={() =>
-                                  this.saveNrql(
-                                    updateDataContextState,
-                                    mapConfig,
-                                    selectedLink,
-                                    tempState,
-                                    i + 1
-                                  )
-                                }
-                              />
-                              <Button
-                                style={{ maxWidth: '52px' }}
-                                icon="delete"
-                                negative
-                                onClick={() =>
-                                  this.deleteNrql(
-                                    updateDataContextState,
-                                    mapConfig,
-                                    selectedLink,
-                                    i + 1
-                                  )
-                                }
-                              />
-                            </div>
-                          </Form.Field>
-                        </Form.Group>
-                      </React.Fragment>
-                    );
-                  })}
+                        <Form.Field width={2}>
+                          <label>&nbsp;</label>
+                          <div style={{ textAlign: 'right' }}>
+                            <Button
+                              style={{ maxWidth: '52px' }}
+                              icon="check"
+                              positive
+                              onClick={() =>
+                                this.saveNrql(
+                                  updateDataContextState,
+                                  mapConfig,
+                                  selectedLink,
+                                  tempState,
+                                  i + 1
+                                )
+                              }
+                            />
+                            <Button
+                              style={{ maxWidth: '52px' }}
+                              icon="delete"
+                              negative
+                              onClick={() =>
+                                this.deleteNrql(
+                                  updateDataContextState,
+                                  mapConfig,
+                                  selectedLink,
+                                  i + 1
+                                )
+                              }
+                            />
+                          </div>
+                        </Form.Field>
+                      </Form.Group>
+                    </React.Fragment>
+                  );
+                })}
 
-                  {/* <Button
+                {/* <Button
                     positive
                     style={{ float: 'right' }}
                     onClick={() =>
@@ -284,11 +287,8 @@ export default class HoverMetrics extends React.PureComponent {
                     />
                     Save
                   </Button> */}
-                  <br />
-                </>
-              ) : (
-                ''
-              )}
+                <br />
+              </div>
             </>
           );
         }}

--- a/nerdlets/observability-maps-nerdlet/components/link/edit/hover-metrics.js
+++ b/nerdlets/observability-maps-nerdlet/components/link/edit/hover-metrics.js
@@ -25,8 +25,7 @@ export default class HoverMetrics extends React.PureComponent {
       hm_1_ACC: null,
       hm_2_ACC: null,
       hm_3_ACC: null,
-      selectedHoverOption: null,
-      editorsSet: false
+      selectedHoverOption: null
     };
   }
 

--- a/nerdlets/observability-maps-nerdlet/components/link/edit/hover-metrics.js
+++ b/nerdlets/observability-maps-nerdlet/components/link/edit/hover-metrics.js
@@ -86,11 +86,12 @@ export default class HoverMetrics extends React.PureComponent {
     tempState,
     no
   ) => {
-    mapConfig.linkData[linkId].hoverMetrics = {
-      [no]: {
-        nrql: this.state[`hm_${no}_NRQL`] || tempState[[`hm_${no}_NRQL`]],
-        accountId: this.state[`hm_${no}_ACC`] || tempState[`hm_${no}_ACC`]
-      }
+    if (!mapConfig.linkData[linkId].hoverMetrics) {
+      mapConfig.linkData[linkId].hoverMetrics = {};
+    }
+    mapConfig.linkData[linkId].hoverMetrics[no] = {
+      nrql: this.state[`hm_${no}_NRQL`] || tempState[[`hm_${no}_NRQL`]],
+      accountId: this.state[`hm_${no}_ACC`] || tempState[`hm_${no}_ACC`]
     };
     await updateDataContextState({ mapConfig }, ['saveMap']);
   };

--- a/nr1.json
+++ b/nr1.json
@@ -1,6 +1,6 @@
 {
   "schemaType": "NERDPACK",
-  "id": "80bfea02-fdb5-4d36-b3cf-68a3a4a07878",
+  "id": "e3c8de28-21c2-4977-89f3-c97d1667d722",
   "displayName": "Observability Maps",
   "description": "Create an observability map based on any of the data available in New Relic."
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2659,7 +2659,7 @@
       }
     },
     "react-d3-graph": {
-      "version": "github:Kav91/react-d3-graph#6df585ba9491b2db5fbb0bfdb02f96d48d8d4ec2",
+      "version": "github:Kav91/react-d3-graph#e8283ecf0a3fa4995e8601c8eefbd835a0696bc5",
       "from": "github:Kav91/react-d3-graph#v0.0.2",
       "requires": {
         "react-tooltip": "^3.11.1"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "nr1-observability-maps",
   "description": "Observability Maps",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "scripts": {
     "start": "nr1 nerdpack:serve",
     "test": "exit 0",

--- a/package.json
+++ b/package.json
@@ -10,19 +10,19 @@
     "eslint-fix": "eslint nerdlets/ --fix"
   },
   "dependencies": {
-    "ace-builds": "^1.4.11",
+    "ace-builds": "^1.4.12",
     "d3": "^5.12.0",
     "graphql": "^14.7.0",
     "graphql-tag": "^2.10.4",
     "prop-types": "^15.6.2",
     "react": "16.6.3",
-    "react-ace": "^9.0.0",
+    "react-ace": "^9.1.1",
     "react-d3-graph": "github:Kav91/react-d3-graph#v0.0.2",
     "react-dom": "16.6.3",
     "react-event-timeline": "^1.6.3",
     "react-select": "^3.1.0",
-    "semantic-ui-react": "^0.88.2",
     "react-toastify": "^5.5.0",
+    "semantic-ui-react": "^0.88.2",
     "semver": "^7.1.3"
   },
   "browserslist": [


### PR DESCRIPTION
Editor is not rendered when link is on default mode, so is undefined when the editors are being setup.
Editor still renders if link is set to NRQL mode.

Fix to always render editors, and toggle display instead.

Fixes #28 