### PR TITLE
fix: remove graphql-tag

### DIFF
--- a/nerdlets/observability-maps-nerdlet/lib/utils.js
+++ b/nerdlets/observability-maps-nerdlet/lib/utils.js
@@ -4,13 +4,13 @@ import {
   UserStorageQuery,
   UserStorageMutation,
   AccountStorageQuery,
-  AccountStorageMutation
+  AccountStorageMutation,
+  ngql
 } from 'nr1';
-import gql from 'graphql-tag';
 
 export const nerdGraphQuery = async query => {
   const nerdGraphData = await NerdGraphQuery.query({
-    query: gql`
+    query: ngql`
       ${query}
     `
   });
@@ -97,7 +97,7 @@ export const nrdbQuery = async (accountId, query, timeout) => {
 };
 
 // no need to run directly, nrdbQuery just passes it through
-export const gqlNrqlQuery = (accountId, query, timeout) => gql`{
+export const gqlNrqlQuery = (accountId, query, timeout) => ngql`{
       actor {
         account(id: ${accountId}) {
           nrql(query: "${query}", timeout: ${timeout || 30000}) {
@@ -108,7 +108,7 @@ export const gqlNrqlQuery = (accountId, query, timeout) => gql`{
     }`;
 
 // search for entities by domain & account
-export const entitySearchByAccountQuery = (domain, accountId, cursor) => gql`{
+export const entitySearchByAccountQuery = (domain, accountId, cursor) => ngql`{
   actor {
     entitySearch(query: "domain IN ('${domain}') AND reporting = 'true' ${
   accountId ? `AND tags.accountId IN ('${accountId}')` : ''

--- a/package-lock.json
+++ b/package-lock.json
@@ -1806,11 +1806,6 @@
         "iterall": "^1.2.2"
       }
     },
-    "graphql-tag": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.11.0.tgz",
-      "integrity": "sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA=="
-    },
     "gud": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
@@ -2667,11 +2662,8 @@
       }
     },
     "react-d3-graph": {
-      "version": "github:Kav91/react-d3-graph#e8283ecf0a3fa4995e8601c8eefbd835a0696bc5",
-      "from": "github:Kav91/react-d3-graph#v0.0.2",
-      "requires": {
-        "react-tooltip": "^3.11.1"
-      }
+      "version": "github:Kav91/react-d3-graph#d75b99f7bc9ee2c217d79a0a78f0582dbda2c84c",
+      "from": "github:Kav91/react-d3-graph#v0.0.3"
     },
     "react-dom": {
       "version": "16.6.3",
@@ -2743,14 +2735,6 @@
         "classnames": "^2.2.6",
         "prop-types": "^15.7.2",
         "react-transition-group": "^4"
-      }
-    },
-    "react-tooltip": {
-      "version": "3.11.6",
-      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-3.11.6.tgz",
-      "integrity": "sha512-nTc1yHHaPCHHURvMpf/VNF17pIZiU4zwUGFJBUVr1fZkezFC7E0VPMMVrCfDjt+IpwTHICyzlyx+1FiQ7lw5LQ==",
-      "requires": {
-        "prop-types": "^15.6.0"
       }
     },
     "react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "ace-builds": "^1.4.12",
     "d3": "^5.12.0",
     "graphql": "^14.7.0",
-    "graphql-tag": "^2.11.0",
     "prop-types": "^15.6.2",
     "react": "16.6.3",
     "react-ace": "^9.3.0",


### PR DESCRIPTION
with liz's insight: 

> there’s actually a platform version of graphql tag that you can import from nr1 ngql and replace any instances of gql and then you don’t need to add the webpack stuff and can delete grapql-tag

* swap to using ngql from 'nr1'. this allows us to remove the
graphql-tag dependency.